### PR TITLE
test: fixed typo in sign_in spec file and added register spec file

### DIFF
--- a/spec/register_spec.rb
+++ b/spec/register_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe 'User sign up', type: :system do
+    scenario "with valid data" do
+        visit new_user_registration_path
+        fill_in "user_email", with: "abcd@abcd.cl"
+        fill_in "user_password", with: "password"
+        fill_in "user_password_confirmation", with: "password"
+        click_button "Sign up"
+        expect(page).to have_content("Welcome! You have signed up successfully.")
+    end
+
+    scenario "without any data" do
+        visit new_user_registration_path
+        click_button "Sign up"
+        expect(page).to have_content("2 errors prohibited this user from being saved:")
+    end
+
+    scenario "with valid user and invalid password" do
+        visit new_user_registration_path
+        fill_in "user_email", with: "irina@abcd.cl"
+        fill_in "user_password", with: "hola"
+        fill_in "user_password_confirmation", with: "hola"
+        click_button "Sign up"
+        expect(page).to have_content("Password is too short (minimum is 6 characters)")
+    end
+
+    scenario "with wrong validation password" do
+        visit new_user_registration_path
+        fill_in "user_email", with: "irina@abcd.cl"
+        fill_in "user_password", with: "password"
+        fill_in "user_password_confirmation", with: "hola"
+        click_button "Sign up"
+        expect(page).to have_content("Password confirmation doesn't match Password")
+    end
+
+    scenario "with user already occupied" do
+        visit new_user_registration_path
+        fill_in "user_email", with: "abcd@abcd.cl"
+        fill_in "user_password", with: "password"
+        fill_in "user_password_confirmation", with: "password"
+        click_button "Sign up"
+        expect(page).to have_content("Email has already been taken")
+    end
+end

--- a/spec/sign_in_spec.rb
+++ b/spec/sign_in_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "User signs in", type: :system do
+RSpec.describe "User signs in", type: :system do
   scenario "valid with correct credentials" do
     visit root_path
     sleep(1)


### PR DESCRIPTION
## What?
- Fixed typo in sign_in_spec file
- Added register_spec file

## Why?
- The Rspec.describe had a typo mistake
- Tests were needed for the registration feature

## Tests?
Registration feature:
- with valid data
- without any data
- with valid user and invalid password
- with wrong validation password
- with user already occupied

## Screenshots
None

## Anything else?
None